### PR TITLE
Fix ServiceTrade logo theme handling for dark/light modes

### DIFF
--- a/web/src/components/logo/Logo.tsx
+++ b/web/src/components/logo/Logo.tsx
@@ -16,7 +16,7 @@ export function Logo({
   size?: "small" | "default" | "large";
 }) {
   const settings = useContext(SettingsContext);
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
 
   const sizeMap = {
     small: { height: 24, width: 22 },
@@ -36,7 +36,7 @@ export function Logo({
     return (
       <div style={{ height, width }} className={className}>
 			<img
-				src={theme === "dark" ? "/logo-dark.png" : "/logo.png"}
+				src={resolvedTheme === "dark" ? "/logo-dark.png" : "/logo.png"}
 				alt="Logo"
 				style={{ objectFit: "contain", height, width }}
 			/>
@@ -64,11 +64,11 @@ export function LogoType({
 }: {
   size?: "small" | "default" | "large";
 }) {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   
   return (
     <img
-		src={theme === "dark" ? "/logotype-dark.png" : "/logotype.png"}
+		src={resolvedTheme === "dark" ? "/logotype-dark.png" : "/logotype.png"}
 		alt="Logo"
 		style={{ objectFit: "contain" }}
 		className="items-center w-full"

--- a/web/src/components/logo/Logo.tsx
+++ b/web/src/components/logo/Logo.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useContext } from "react";
+import { useTheme } from "next-themes";
 import { SettingsContext } from "../settings/SettingsProvider";
-import { OnyxIcon, OnyxLogoTypeIcon } from "../icons/icons";
 
 export function Logo({
   height,
@@ -16,6 +16,7 @@ export function Logo({
   size?: "small" | "default" | "large";
 }) {
   const settings = useContext(SettingsContext);
+  const { theme } = useTheme();
 
   const sizeMap = {
     small: { height: 24, width: 22 },
@@ -35,7 +36,7 @@ export function Logo({
     return (
       <div style={{ height, width }} className={className}>
 			<img
-				src="/logo-dark.png"
+				src={theme === "dark" ? "/logo-dark.png" : "/logo.png"}
 				alt="Logo"
 				style={{ objectFit: "contain", height, width }}
 			/>
@@ -63,9 +64,11 @@ export function LogoType({
 }: {
   size?: "small" | "default" | "large";
 }) {
+  const { theme } = useTheme();
+  
   return (
     <img
-		src="/logotype-dark.png"
+		src={theme === "dark" ? "/logotype-dark.png" : "/logotype.png"}
 		alt="Logo"
 		style={{ objectFit: "contain" }}
 		className="items-center w-full"


### PR DESCRIPTION
# Fix ServiceTrade logo dark/light mode handling

This PR fixes the ServiceTrade logo implementation to properly handle dark/light mode theme switching. Now the appropriate logo file is used based on the user's selected theme.

## Changes:
- Added useTheme hook from next-themes to Logo.tsx
- Updated Logo component to conditionally render logo-dark.png or logo.png based on theme
- Updated LogoType component to conditionally render logotype-dark.png or logotype.png based on theme

Link to Devin run: https://app.devin.ai/sessions/8a502d6734264ceeba2625b3619124ef
Requested by: james.jordan@servicetrade.com