### PR TITLE
feat: Add Claude Sonnet 4.5 support

### DIFF
--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -270,7 +270,7 @@ def configure_default_api_keys(db_session: Session) -> None:
             name="Anthropic",
             provider=ANTHROPIC_PROVIDER_NAME,
             api_key=ANTHROPIC_DEFAULT_API_KEY,
-            default_model_name="claude-3-7-sonnet-20250219",
+            default_model_name="claude-sonnet-4-5-20250929",
             fast_default_model_name="claude-3-5-sonnet-20241022",
             model_configurations=[
                 ModelConfigurationUpsertRequest(

--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -95,9 +95,16 @@ ANTHROPIC_MODEL_NAMES = [
     for model in litellm.anthropic_models
     if model not in IGNORABLE_ANTHROPIC_MODELS
 ][::-1]
+# Ensure latest models are included even if litellm hasn't been updated yet
+if "claude-sonnet-4-5-20250929" not in ANTHROPIC_MODEL_NAMES:
+    ANTHROPIC_MODEL_NAMES.insert(0, "claude-sonnet-4-5-20250929")
+if "claude-3-7-sonnet-20250219" not in ANTHROPIC_MODEL_NAMES:
+    ANTHROPIC_MODEL_NAMES.insert(0, "claude-3-7-sonnet-20250219")
+
 ANTHROPIC_VISIBLE_MODEL_NAMES = [
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-4-5-20250929",
     "claude-3-7-sonnet-20250219",
+    "claude-3-5-sonnet-20241022",
 ]
 
 AZURE_PROVIDER_NAME = "azure"
@@ -179,7 +186,7 @@ def fetch_available_well_known_llms() -> list[WellKnownLLMProviderDescriptor]:
             model_configurations=fetch_model_configurations_for_provider(
                 ANTHROPIC_PROVIDER_NAME
             ),
-            default_model="claude-3-7-sonnet-20250219",
+            default_model="claude-sonnet-4-5-20250929",
             default_fast_model="claude-3-5-sonnet-20241022",
         ),
         WellKnownLLMProviderDescriptor(

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -725,6 +725,7 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "claude-3-5-sonnet-20240620": "Claude 3.5 Sonnet (June 2024)",
   "claude-3-5-sonnet-20241022": "Claude 3.5 Sonnet",
   "claude-3-7-sonnet-20250219": "Claude 3.7 Sonnet",
+  "claude-sonnet-4-5-20250929": "Claude Sonnet 4.5",
   "claude-3-5-sonnet-v2@20241022": "Claude 3.5 Sonnet",
   "claude-3.5-sonnet-v2@20241022": "Claude 3.5 Sonnet",
   "claude-3-5-haiku-20241022": "Claude 3.5 Haiku",
@@ -789,6 +790,8 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "anthropic.claude-v2:1": "Claude v2.1",
   "anthropic.claude-v2": "Claude v2",
   "anthropic.claude-v1": "Claude v1",
+  "anthropic.claude-sonnet-4-5-20250929-v1:0": "Claude Sonnet 4.5",
+  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": "Claude Sonnet 4.5",
   "anthropic.claude-3-7-sonnet-20250219-v1:0": "Claude 3.7 Sonnet",
   "us.anthropic.claude-3-7-sonnet-20250219-v1:0": "Claude 3.7 Sonnet",
   "anthropic.claude-3-opus-20240229-v1:0": "Claude 3 Opus",
@@ -834,6 +837,7 @@ export const defaultModelsByProvider: { [name: string]: string[] } = {
     "o3",
   ],
   bedrock: [
+    "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "meta.llama3-1-70b-instruct-v1:0",
     "meta.llama3-1-8b-instruct-v1:0",
     "anthropic.claude-3-opus-20240229-v1:0",
@@ -841,5 +845,9 @@ export const defaultModelsByProvider: { [name: string]: string[] } = {
     "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "anthropic.claude-3-7-sonnet-20250219-v1:0",
   ],
-  anthropic: ["claude-3-opus-20240229", "claude-3-5-sonnet-20241022"],
+  anthropic: [
+    "claude-sonnet-4-5-20250929",
+    "claude-3-opus-20240229",
+    "claude-3-5-sonnet-20241022",
+  ],
 };


### PR DESCRIPTION
## Summary
- Add Claude Sonnet 4.5 (claude-sonnet-4-5-20250929) as the new default model for Anthropic provider
- Update model display names and provider configurations across backend and frontend
- Ensure Claude Sonnet 4.5 is included in model lists even if litellm hasn't been updated yet

## Changes
**Backend:**
- Updated default Anthropic model in tenant provisioning to use Claude Sonnet 4.5
- Added Claude Sonnet 4.5 to ANTHROPIC_MODEL_NAMES with fallback logic for litellm compatibility
- Set Claude Sonnet 4.5 as the default model in well-known LLM provider descriptors

**Frontend:**
- Added display name "Claude Sonnet 4.5" for the new model
- Added Bedrock provider model IDs for Claude Sonnet 4.5 (both standard and us regions)
- Updated default models list for Anthropic and Bedrock providers to include Claude Sonnet 4.5

## Test plan
- [ ] Verify Claude Sonnet 4.5 appears as the default model in tenant provisioning
- [ ] Confirm model selection UI displays "Claude Sonnet 4.5" correctly
- [ ] Test chat functionality with Claude Sonnet 4.5 via Anthropic provider
- [ ] Test chat functionality with Claude Sonnet 4.5 via Bedrock provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)